### PR TITLE
Add client_pwd toggle

### DIFF
--- a/terraform-aws/client.tf
+++ b/terraform-aws/client.tf
@@ -17,7 +17,7 @@ data "template_file" "client_userdata_script" {
     security_enabled        = "${var.security_enabled}"
     monitoring_enabled      = "${var.monitoring_enabled}"
     client_user             = "${var.client_user}"
-    client_pwd              = "${random_string.vm-login-password.result}"
+    client_pwd              = "${local.client_pwd}"
   }
 }
 

--- a/terraform-aws/main.tf
+++ b/terraform-aws/main.tf
@@ -8,6 +8,10 @@ resource "random_string" "vm-login-password" {
   override_special = "!@#%&-_"
 }
 
+locals {
+  client_pwd = "${var.client_pwd != "GENERATE" ? var.client_pwd : format("%s", random_string.vm-login-password.result)}"
+}
+
 data "aws_availability_zones" "available" {}
 
 ##############################################################################

--- a/terraform-aws/outputs.tf
+++ b/terraform-aws/outputs.tf
@@ -3,5 +3,5 @@ output "clients_dns" {
 }
 
 output "vm_password" {
-  value = "${random_string.vm-login-password.result}"
+  value = "${local.client_pwd}"
 }

--- a/terraform-aws/single-node.tf
+++ b/terraform-aws/single-node.tf
@@ -17,7 +17,7 @@ data "template_file" "single_node_userdata_script" {
     security_enabled        = "${var.security_enabled}"
     monitoring_enabled      = "${var.monitoring_enabled}"
     client_user             = "${var.client_user}"
-    client_pwd              = "${random_string.vm-login-password.result}"
+    client_pwd              = "${local.client_pwd}"
   }
 }
 

--- a/terraform-aws/variables.tf
+++ b/terraform-aws/variables.tf
@@ -119,3 +119,8 @@ variable "lb_port" {
   description = "The port the load balancer should listen on for API requests."
   default     = 80
 }
+
+variable "client_pwd" {
+  description = "Set admin password for kibana, generated if not provided"
+  default = "GENERATE"
+}

--- a/terraform-azure/clients.tf
+++ b/terraform-azure/clients.tf
@@ -18,7 +18,7 @@ data "template_file" "client_userdata_script" {
     security_enabled        = "${var.security_enabled}"
     monitoring_enabled      = "${var.monitoring_enabled}"
     client_user             = "${var.client_user}"
-    client_pwd              = "${random_string.vm-login-password.result}"
+    client_pwd              = "${local.client_pwd}"
   }
 }
 

--- a/terraform-azure/main.tf
+++ b/terraform-azure/main.tf
@@ -11,6 +11,10 @@ resource "random_string" "vm-login-password" {
   override_special = "!@#%&-_"
 }
 
+locals {
+  client_pwd = "${var.client_pwd != "GENERATE" ? var.client_pwd : format("%s", random_string.vm-login-password.result)}"
+}
+
 resource "azurerm_resource_group" "elasticsearch" {
   location = "${var.azure_location}"
   name = "elasticsearch-cluster-${var.es_cluster}"

--- a/terraform-azure/single-node.tf
+++ b/terraform-azure/single-node.tf
@@ -18,7 +18,7 @@ data "template_file" "singlenode_userdata_script" {
     security_enabled        = "${var.security_enabled}"
     monitoring_enabled      = "${var.monitoring_enabled}"
     client_user             = "${var.client_user}"
-    client_pwd              = "${random_string.vm-login-password.result}"
+    client_pwd              = "${local.client_pwd}"
   }
 }
 

--- a/terraform-azure/variables.tf
+++ b/terraform-azure/variables.tf
@@ -106,3 +106,8 @@ variable "monitoring_enabled" {
 variable "client_user" {
   default = "exampleuser"
 }
+
+variable "client_pwd" {
+  description = "Set admin password for kibana, generated if not provided"
+  default = "GENERATE"
+}


### PR DESCRIPTION
This PR makes module to be backward compatible for those who has no luxury of changing password on running clusters.
If client_pwd is not passed it will be generated as with current master.