### PR TITLE
Allow specifying subnets, on which client nodes and load balancer will run

### DIFF
--- a/terraform-aws/client.tf
+++ b/terraform-aws/client.tf
@@ -57,7 +57,7 @@ resource "aws_autoscaling_group" "client_nodes" {
 
   load_balancers = ["${aws_elb.es_client_lb.id}"]
 
-  vpc_zone_identifier = ["${data.aws_subnet_ids.selected.ids}"]
+  vpc_zone_identifier   = ["${coalescelist(var.clients_subnet_ids, list(data.aws_subnet_ids.selected.ids[0]))}"]
 
   tag {
     key                 = "Name"

--- a/terraform-aws/main.tf
+++ b/terraform-aws/main.tf
@@ -103,7 +103,7 @@ resource "aws_elb" "es_client_lb" {
 
   name            = "${format("%s-client-lb", var.es_cluster)}"
   security_groups = ["${aws_security_group.elasticsearch_clients_security_group.id}"]
-  subnets         = ["${data.aws_subnet_ids.selected.ids}"]
+  subnets         = ["${coalescelist(var.clients_subnet_ids, list(data.aws_subnet_ids.selected.ids[0]))}"]
   internal        = "${var.public_facing == "true" ? "false" : "true"}"
 
   cross_zone_load_balancing   = true

--- a/terraform-aws/masters.tf
+++ b/terraform-aws/masters.tf
@@ -127,6 +127,7 @@ resource "aws_instance" "bootstrap_node" {
   iam_instance_profile = "${aws_iam_instance_profile.elasticsearch.id}"
   user_data = "${data.template_file.bootstrap_userdata_script.rendered}"
   key_name = "${var.key_name}"
+  subnet_id = "${data.aws_subnet_ids.selected.ids[0]}"
 
   tags {
     Name = "${var.es_cluster}-bootstrap-node"

--- a/terraform-aws/masters.tf
+++ b/terraform-aws/masters.tf
@@ -123,7 +123,7 @@ resource "aws_instance" "bootstrap_node" {
   instance_type = "${var.master_instance_type}"
   instance_initiated_shutdown_behavior = "terminate"
   vpc_security_group_ids = ["${concat(list(aws_security_group.elasticsearch_security_group.id), var.additional_security_groups)}"]
-  associate_public_ip_address = false
+  associate_public_ip_address = true
   iam_instance_profile = "${aws_iam_instance_profile.elasticsearch.id}"
   user_data = "${data.template_file.bootstrap_userdata_script.rendered}"
   key_name = "${var.key_name}"

--- a/terraform-aws/variables.tf
+++ b/terraform-aws/variables.tf
@@ -12,6 +12,12 @@ variable "vpc_id" {
   type = "string"
 }
 
+variable "clients_subnet_ids" {
+  description = "Subnets to run client nodes and client ELB in. Only one subnet per availability zone allowed. Will detect a single subnet by default." 
+  type = "list"
+  default = []
+}
+
 variable "availability_zones" {
   type = "list"
   description = "AWS region to launch servers; if not set the available zones will be detected automatically"


### PR DESCRIPTION
Adds `clients_subnet_ids` variable. Terraform apply will fail if the list contains multiple subnets from the same availability zone.  
By default, a single subnet will be selected to avoid availability zone errors.