### PR TITLE
Force public IPs for data and client nodes

### DIFF
--- a/terraform-aws/client.tf
+++ b/terraform-aws/client.tf
@@ -32,7 +32,7 @@ resource "aws_launch_configuration" "client" {
   image_id = "${data.aws_ami.kibana_client.id}"
   instance_type = "${var.master_instance_type}"
   security_groups = ["${concat(list(aws_security_group.elasticsearch_security_group.id), list(aws_security_group.elasticsearch_clients_security_group.id), var.additional_security_groups)}"]
-  associate_public_ip_address = false
+  associate_public_ip_address = true
   iam_instance_profile = "${aws_iam_instance_profile.elasticsearch.id}"
   user_data = "${data.template_file.client_userdata_script.rendered}"
   key_name = "${var.key_name}"

--- a/terraform-aws/datas.tf
+++ b/terraform-aws/datas.tf
@@ -29,7 +29,7 @@ resource "aws_launch_configuration" "data" {
   image_id = "${data.aws_ami.elasticsearch.id}"
   instance_type = "${var.data_instance_type}"
   security_groups = ["${concat(list(aws_security_group.elasticsearch_security_group.id), var.additional_security_groups)}"]
-  associate_public_ip_address = false
+  associate_public_ip_address = true
   iam_instance_profile = "${aws_iam_instance_profile.elasticsearch.id}"
   user_data = "${data.template_file.data_userdata_script.rendered}"
   key_name = "${var.key_name}"


### PR DESCRIPTION
EC2 discovery plugin requires internet access to work. Forcing public IPs on data and client nodes, to let the discovery plugin work.