### PR TITLE
Allow running cluster in private subnets

### DIFF
--- a/templates/user_data.sh
+++ b/templates/user_data.sh
@@ -6,13 +6,13 @@ if [ "${bootstrap_node}" == "true"  ]; then
     while true
     do
         echo "Fetching masters..."
-        MASTER_INSTANCES="$(aws autoscaling describe-auto-scaling-groups --region ${aws_region} --auto-scaling-group-names ${asg_name} | jq -r '.AutoScalingGroups[0].Instances[].InstanceId' | sort)"
+        MASTER_INSTANCES="$(aws ec2 describe-instances --region=${aws_region} --filters Name=instance-state-name,Values=running Name=tag:Role,Values=master Name=tag:Cluster,Values=${es_environment} | jq -r '.Reservations | map(.Instances[].InstanceId) | .[]' | sort)"
         COUNT=`echo "$MASTER_INSTANCES" | wc -l`
 
         if [ "$COUNT" -eq "${masters_count}" ]; then
             echo "Masters count is correct... Rechecking in 60 sec"
             sleep 60
-            MASTER_INSTANCES_RECHECK="$(aws autoscaling describe-auto-scaling-groups --region ${aws_region} --auto-scaling-group-names ${asg_name} | jq -r '.AutoScalingGroups[0].Instances[].InstanceId' | sort)"
+            MASTER_INSTANCES_RECHECK="$(aws ec2 describe-instances --region=${aws_region} --filters Name=instance-state-name,Values=running Name=tag:Role,Values=master Name=tag:Cluster,Values=${es_environment} | jq -r '.Reservations | map(.Instances[].InstanceId) | .[]' | sort)"
         
             if [ "$MASTER_INSTANCES" = "$MASTER_INSTANCES_RECHECK" ]; then
                 break

--- a/terraform-aws/client.tf
+++ b/terraform-aws/client.tf
@@ -20,7 +20,6 @@ data "template_file" "client_userdata_script" {
     client_user             = "${var.client_user}"
     client_pwd              = "${random_string.vm-login-password.result}"
     xpack_monitoring_host   = "${var.xpack_monitoring_host}"
-    asg_name                = ""
   }
 }
 
@@ -32,7 +31,7 @@ resource "aws_launch_configuration" "client" {
   image_id = "${data.aws_ami.kibana_client.id}"
   instance_type = "${var.master_instance_type}"
   security_groups = ["${concat(list(aws_security_group.elasticsearch_security_group.id), list(aws_security_group.elasticsearch_clients_security_group.id), var.additional_security_groups)}"]
-  associate_public_ip_address = true
+  associate_public_ip_address = false
   iam_instance_profile = "${aws_iam_instance_profile.elasticsearch.id}"
   user_data = "${data.template_file.client_userdata_script.rendered}"
   key_name = "${var.key_name}"

--- a/terraform-aws/datas.tf
+++ b/terraform-aws/datas.tf
@@ -20,7 +20,6 @@ data "template_file" "data_userdata_script" {
     client_user             = ""
     client_pwd              = ""
     xpack_monitoring_host   = "${var.xpack_monitoring_host}"
-    asg_name                = ""
   }
 }
 
@@ -29,7 +28,7 @@ resource "aws_launch_configuration" "data" {
   image_id = "${data.aws_ami.elasticsearch.id}"
   instance_type = "${var.data_instance_type}"
   security_groups = ["${concat(list(aws_security_group.elasticsearch_security_group.id), var.additional_security_groups)}"]
-  associate_public_ip_address = true
+  associate_public_ip_address = false
   iam_instance_profile = "${aws_iam_instance_profile.elasticsearch.id}"
   user_data = "${data.template_file.data_userdata_script.rendered}"
   key_name = "${var.key_name}"
@@ -57,7 +56,7 @@ resource "aws_autoscaling_group" "data_nodes" {
   force_delete = true
   launch_configuration = "${aws_launch_configuration.data.id}"
 
-  vpc_zone_identifier = ["${data.aws_subnet_ids.selected.ids}"]
+  vpc_zone_identifier = ["${coalescelist(var.cluster_subnet_ids, data.aws_subnet_ids.selected.ids)}"]
 
   depends_on = ["aws_autoscaling_group.master_nodes"]
 

--- a/terraform-aws/variables.tf
+++ b/terraform-aws/variables.tf
@@ -18,6 +18,12 @@ variable "clients_subnet_ids" {
   default = []
 }
 
+variable "cluster_subnet_ids" {
+  description = "Cluster nodes subnets. Defaults to all VPC subnets." 
+  type = "list"
+  default = []
+}
+
 variable "availability_zones" {
   type = "list"
   description = "AWS region to launch servers; if not set the available zones will be detected automatically"

--- a/terraform-aws/vpc.tf
+++ b/terraform-aws/vpc.tf
@@ -5,3 +5,32 @@ data "aws_vpc" "selected" {
 data "aws_subnet_ids" "selected" {
   vpc_id = "${var.vpc_id}"
 }
+
+resource "aws_security_group" "vpc-endpoint" {
+  vpc_id = "${var.vpc_id}" 
+
+  ingress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port       = 0
+    to_port         = 0
+    protocol        = "-1"
+    cidr_blocks     = ["0.0.0.0/0"]
+  }
+}
+
+
+resource "aws_vpc_endpoint" "ec2" {
+  vpc_id = "${var.vpc_id}"
+  service_name = "com.amazonaws.${var.aws_region}.ec2"
+  vpc_endpoint_type = "Interface"
+  private_dns_enabled = true
+
+  security_group_ids = ["${aws_security_group.vpc-endpoint.id}"]
+  subnet_ids = ["${coalescelist(var.cluster_subnet_ids, data.aws_subnet_ids.selected.ids)}"]
+}


### PR DESCRIPTION
* Disables assigning public IPs to data and client nodes. Creates a VPC endpoint for accessing EC2 API.
* Adds new optional variable `cluster_subnet_ids` for specifying subnets where non-client nodes should run