### PR TITLE
Disk attach mechanism and misc fixes for AWS/GCP

### DIFF
--- a/assets/scripts/bootstrap.sh
+++ b/assets/scripts/bootstrap.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set +e
 
 . /opt/cloud-deploy-scripts/common/env.sh
 . /opt/cloud-deploy-scripts/$cloud_provider/env.sh

--- a/assets/scripts/client.sh
+++ b/assets/scripts/client.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set +e
 
 . /opt/cloud-deploy-scripts/common/env.sh
 . /opt/cloud-deploy-scripts/$cloud_provider/env.sh

--- a/assets/scripts/data.sh
+++ b/assets/scripts/data.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set +e
 
 . /opt/cloud-deploy-scripts/common/env.sh
 . /opt/cloud-deploy-scripts/$cloud_provider/env.sh

--- a/assets/scripts/gcp/env.sh
+++ b/assets/scripts/gcp/env.sh
@@ -1,1 +1,11 @@
-export GCP_ZONE="$(gcloud compute instances list --filter="name=('"$HOSTNAME"')" --format "value(zone)")"
+# gcloud cli sometimes fails if you use it right after the instance has started up
+# adding a retry for that case
+while true;
+do
+	export GCP_ZONE="$(gcloud compute instances list --filter="name=('"$HOSTNAME"')" --format "value(zone)")"
+	if [ "$GCP_ZONE" != "" ]; then
+		break
+	fi
+	echo "Failed to detect GCP_ZONE. Retrying in 5 seconds..."
+	sleep 5
+done

--- a/assets/scripts/master.sh
+++ b/assets/scripts/master.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set +e
 
 . /opt/cloud-deploy-scripts/common/env.sh
 . /opt/cloud-deploy-scripts/$cloud_provider/env.sh

--- a/assets/scripts/singlenode.sh
+++ b/assets/scripts/singlenode.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set +e
 
 . /opt/cloud-deploy-scripts/common/env.sh
 . /opt/cloud-deploy-scripts/$cloud_provider/env.sh

--- a/templates/aws_user_data.sh
+++ b/templates/aws_user_data.sh
@@ -2,6 +2,11 @@
 
 exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
 
+if [ "${DEV_MODE_scripts_s3_bucket}" != "" ]; then
+	sudo aws s3 cp --recursive "s3://${DEV_MODE_scripts_s3_bucket}" /opt/cloud-deploy-scripts/
+	sudo chmod -R +x /opt/cloud-deploy-scripts
+fi
+
 export cloud_provider="${cloud_provider}"
 export elasticsearch_data_dir="${elasticsearch_data_dir}"
 export elasticsearch_logs_dir="${elasticsearch_logs_dir}"

--- a/terraform-aws/dev.tf
+++ b/terraform-aws/dev.tf
@@ -1,0 +1,22 @@
+data "template_file" "dev-s3" {
+  template = file("${path.module}/../assets/s3-backup.json")
+
+  vars = {
+    s3_backup_bucket = var.DEV_MODE_scripts_s3_bucket
+  }
+}
+
+resource "aws_s3_bucket" "dev" {
+  count = var.DEV_MODE_scripts_s3_bucket == "" ? 0 : 1
+
+  bucket = "${var.DEV_MODE_scripts_s3_bucket}"
+  region = var.aws_region
+  acl    = "private"
+}
+
+resource "aws_iam_role_policy" "dev-s3" {
+  count  = var.DEV_MODE_scripts_s3_bucket != "" ? 1 : 0
+  name   = "${var.es_cluster}-elasticsearch-s3-devmode-policy"
+  role   = aws_iam_role.elasticsearch.id
+  policy = data.template_file.dev-s3.rendered
+}

--- a/terraform-aws/main.tf
+++ b/terraform-aws/main.tf
@@ -59,6 +59,8 @@ locals {
     ca_cert   = var.security_enabled ? join("", tls_self_signed_cert.ca[*].cert_pem) : ""
     node_cert = var.security_enabled ? join("", tls_locally_signed_cert.node[*].cert_pem) : ""
     node_key  = var.security_enabled ? join("", tls_private_key.node[*].private_key_pem) : ""
+
+    DEV_MODE_scripts_s3_bucket = var.DEV_MODE_scripts_s3_bucket
   }
 }
 

--- a/terraform-aws/variables.tf
+++ b/terraform-aws/variables.tf
@@ -156,3 +156,8 @@ variable "bootstrap_node_subnet_id" {
   description = "Use to override which subnet the bootstrap node is created in."
   default     = ""
 }
+
+variable "DEV_MODE_scripts_s3_bucket" {
+  description = "S3 bucket to override init scripts from. Should not be used on production."
+  default     = ""
+}

--- a/terraform-aws/vpc.tf
+++ b/terraform-aws/vpc.tf
@@ -6,6 +6,10 @@ data "aws_subnet_ids" "all-subnets" {
   vpc_id = var.vpc_id
 }
 
+data "aws_route_tables" "vpc_route_tables" {
+  vpc_id = var.vpc_id
+}
+
 data "aws_subnet_ids" "subnets-per-az" {
   count  = length(local.all_availability_zones)
   vpc_id = var.vpc_id
@@ -64,3 +68,9 @@ resource "aws_vpc_endpoint" "autoscaling" {
   ))
 }
 
+resource "aws_vpc_endpoint" "s3" {
+  vpc_id            = var.vpc_id
+  service_name      = "com.amazonaws.${var.aws_region}.s3"
+  vpc_endpoint_type = "Gateway"
+  route_table_ids   = data.aws_route_tables.vpc_route_tables.ids
+}

--- a/terraform-gcp/main.tf
+++ b/terraform-gcp/main.tf
@@ -69,12 +69,14 @@ resource "google_storage_bucket" "snapshots" {
 }
 
 resource "google_storage_bucket_iam_member" "legacy-bucket-reader" {
+  count = var.gcs_snapshots_bucket != "" ? 1 : 0
   bucket = join("", google_storage_bucket.snapshots[*].name)
   role   = "roles/storage.legacyBucketReader"
   member = "serviceAccount:${google_service_account.gcs.email}"
 }
 
 resource "google_storage_bucket_iam_member" "object-admin" {
+  count = var.gcs_snapshots_bucket != "" ? 1 : 0
   bucket = join("", google_storage_bucket.snapshots[*].name)
   role   = "roles/storage.objectAdmin"
   member = "serviceAccount:${google_service_account.gcs.email}"


### PR DESCRIPTION
Change current way of finding a disk to attach when an instance is launched. Instances will try to attach any available disk in a loop, until success.

Misc:
* fix issue with gcloud not being available on startup
* add missing S3 VPC endpoint resource for AWS
* add `DEV_MODE_scripts_s3_bucket` variable for overriding packer init scripts in development for AWS