### PR TITLE
removed / from default xpack.monitoring.host

### DIFF
--- a/terraform-aws/variables.tf
+++ b/terraform-aws/variables.tf
@@ -129,7 +129,7 @@ variable "ebs_optimized" {
 
 variable "xpack_monitoring_host" {
   description = "ES host to send monitoring data"
-  default     = "http://localhost:9200/"
+  default     = "http://localhost:9200"
 }
 
 variable "filebeat_monitoring_host" {

--- a/terraform-gcp/variables.tf
+++ b/terraform-gcp/variables.tf
@@ -117,7 +117,7 @@ variable "client_heap_size" {
 
 variable "xpack_monitoring_host" {
   description = "ES host to send monitoring data"
-  default     = "http://localhost:9200/"
+  default     = "http://localhost:9200"
 }
 
 variable "filebeat_monitoring_host" {


### PR DESCRIPTION
Elasticsearch failed on startup until http://localhost:9200/ was changed to http://localhost:9200